### PR TITLE
Added WebhookFormat and EventTypes to SDK and WebSample projects.

### DIFF
--- a/src/Pinch.SDK.WebSample/Controllers/WebhooksController.cs
+++ b/src/Pinch.SDK.WebSample/Controllers/WebhooksController.cs
@@ -1,13 +1,14 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Pinch.SDK.Webhooks;
+using Pinch.SDK.WebSample.Helpers;
+using Pinch.SDK.WebSample.Models;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
-using Pinch.SDK.Webhooks;
-using Pinch.SDK.WebSample.Helpers;
-using Pinch.SDK.WebSample.Models;
 
 namespace Pinch.SDK.WebSample.Controllers
 {
@@ -27,9 +28,20 @@ namespace Pinch.SDK.WebSample.Controllers
         }
 
         [HttpPost]
-        public async Task<IActionResult> New(WebhookSaveOptions model)
+        public async Task<IActionResult> New(WebhookVm model)
         {
-            var result = await GetApi().Webhook.Save(model);
+            var options = new WebhookSaveOptions()
+            {
+                Uri = model.Uri,
+                WebhookFormat = model.WebhookFormat
+                    ?.ToLower(),
+                EventTypes = model.EventTypes
+                    ?.ToLower()
+                    ?.Split(";, ".ToCharArray(), StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    ?.ToList()  
+            };
+
+            var result = await GetApi().Webhook.Save(options);
 
             if (!result.Success)
             {

--- a/src/Pinch.SDK.WebSample/Models/WebhookVm.cs
+++ b/src/Pinch.SDK.WebSample/Models/WebhookVm.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Pinch.SDK.WebSample.Models
+{
+    public class WebhookVm
+    {
+        public string Uri { get; set; }
+        public string WebhookFormat { get; set; }
+        public string EventTypes { get; set; }
+    }
+}

--- a/src/Pinch.SDK.WebSample/Views/Shared/_Layout.cshtml
+++ b/src/Pinch.SDK.WebSample/Views/Shared/_Layout.cshtml
@@ -48,6 +48,7 @@
                     <li is-active-route asp-controller="Subscriptions" asp-action="Index"><a asp-controller="Subscriptions" asp-action="Index">Subscriptions</a></li>
                     <li is-active-route asp-controller="Transfers"><a asp-controller="Transfers" asp-action="Index">Transfers</a></li>
                     <li is-active-route asp-controller="Events"><a asp-controller="Events" asp-action="Index">Events</a></li>
+                    <li is-active-route asp-controller="Webhooks"><a asp-controller="Webhooks" asp-action="Index">Webhooks</a></li>
                     <li is-active-route asp-controller="Merchants"><a asp-controller="Merchants" asp-action="Index">Merchants</a></li>
                     <li is-active-route asp-controller="Home" asp-action="Connect"><a asp-controller="Home" asp-action="Connect">Connect</a></li>
                 </ul>

--- a/src/Pinch.SDK.WebSample/Views/Webhooks/Index.cshtml
+++ b/src/Pinch.SDK.WebSample/Views/Webhooks/Index.cshtml
@@ -17,6 +17,8 @@
             <th>ID</th>
             <th>Secret</th>
             <th>Uri</th>
+            <th>WebhookFormat</th>
+            <th>EventTypes</th>
         </tr>
     </thead>
     <tbody>
@@ -26,6 +28,8 @@
                 <td>@hook.Id</td>
                 <td>@hook.Secret</td>
                 <td>@hook.Uri</td>
+                <td>@hook.WebhookFormat</td>
+                <td>@string.Join(", ", hook.EventTypes)</td>
             </tr>
         }
     </tbody>

--- a/src/Pinch.SDK.WebSample/Views/Webhooks/New.cshtml
+++ b/src/Pinch.SDK.WebSample/Views/Webhooks/New.cshtml
@@ -1,11 +1,11 @@
-﻿@model  Pinch.SDK.Webhooks.WebhookSaveOptions
+﻿@model Pinch.SDK.WebSample.Models.WebhookVm
 
 @{
     ViewData["Title"] = "New";
     Layout = "~/Views/Shared/_Layout.cshtml";
 }
 
-<h2>New Webook</h2>
+<h2>New Webhook</h2>
 
 <form asp-action="new">
     <div class="form-horizontal">
@@ -17,6 +17,20 @@
             <div class="col-md-10">
                 <input asp-for="Uri" class="form-control" />
                 <span asp-validation-for="Uri" class="text-danger"></span>
+            </div>
+        </div>
+        <div class="form-group">
+            <label asp-for="WebhookFormat" class="col-md-2 control-label"></label>
+            <div class="col-md-10">
+                <input asp-for="WebhookFormat" class="form-control" />
+                <span asp-validation-for="WebhookFormat" class="text-danger"></span>
+            </div>
+        </div>
+        <div class="form-group">
+            <label asp-for="EventTypes" class="col-md-2 control-label"></label>
+            <div class="col-md-10">
+                <input asp-for="EventTypes" class="form-control" />
+                <span asp-validation-for="EventTypes" class="text-danger"></span>
             </div>
         </div>
 

--- a/src/Pinch.SDK/Webhooks/EventTypes.cs
+++ b/src/Pinch.SDK/Webhooks/EventTypes.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Pinch.SDK.Webhooks
+{
+    public static class EventTypes
+    {
+        public const string BankResults = "bank-results";
+        public const string ScheduledProcess = "scheduled-process";
+        public const string Transfer = "transfer";
+        public const string RealtimePayment = "realtime-payment";
+        public const string PaymentCreated = "payment-created";
+        public const string SubscriptionComplete = "subscription-complete";
+        public const string PayerCreated = "payer-created";
+        public const string PayerUpdated = "payer-updated";
+        public const string RefundCreated = "refund-created";
+        public const string RefundUpdated = "refund-updated";
+
+        public const string ComplianceUpdated = "compliance-updated";
+        public const string DisputeCreated = "dispute-created";
+        public const string DisputeUpdated = "dispute-updated";
+        public const string MerchantCreated = "merchant-created";
+        public const string MerchantUpdated = "merchant-updated";
+
+        public const string MerchantComplianceUpdated = "merchant-compliance-updated";
+        public const string SubscriptionCreated = "subscription-created";
+        public const string SubscriptionCancelled = "subscription-cancelled";
+        public const string ReportOnlyPayment = "reportonly-payment";
+
+    }
+}

--- a/src/Pinch.SDK/Webhooks/Webhook.cs
+++ b/src/Pinch.SDK/Webhooks/Webhook.cs
@@ -11,5 +11,7 @@ namespace Pinch.SDK.Webhooks
         public string Id { get; set; }
         public string Secret { get; set; }
         public string Uri { get; set; }
+        public string WebhookFormat { get; set; }
+        public List<string> EventTypes { get; set; }
     }
 }

--- a/src/Pinch.SDK/Webhooks/WebhookFormats.cs
+++ b/src/Pinch.SDK/Webhooks/WebhookFormats.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Pinch.SDK.Webhooks
+{
+    public static class WebhookFormats
+    {
+        public const string PascalCase = "pascal-case";
+        public const string CamelCase = "camel-case";
+    }
+}

--- a/src/Pinch.SDK/Webhooks/WebhookSaveOptions.cs
+++ b/src/Pinch.SDK/Webhooks/WebhookSaveOptions.cs
@@ -8,6 +8,19 @@ namespace Pinch.SDK.Webhooks
 {
     public class WebhookSaveOptions
     {
+        /// <summary>
+        /// This is the uri that the webhooks will be sent to.
+        /// </summary>
         public string Uri { get; set; }
+
+        /// <summary>
+        /// Optional. See WebhookFormats for the list of available formats. Defaults to PascalCase.
+        /// </summary>
+        public string WebhookFormat { get; set; }
+
+        /// <summary>
+        /// Optional. This is a list of the types of events that will be returned via the webhook. See EventTypes for a list of available events. Defaults to ALL event types. 
+        /// </summary>
+        public List<string> EventTypes { get; set; }
     }
 }


### PR DESCRIPTION
https://app.asana.com/1/1143636915694331/project/1204692552741423/task/1210395302029834

	[x] - Have linked asana ticket.
	[x] - Have added test plan to asana ticket.
	[x] - Have tested locally.
	[x] - Have included screenshot on PR.

I've added both the WebhookFormat and EventTypes to the SDK and the WebSample - However the WebhookResponse returned from the API doesn't include the WebhookFormat as it doesn't display in the Merchants Webhooks page. Should we remove WebhookFormat? We either keep it and update the API (either now or later) or remove it as it won't display any values and is potentially misleading.

Also, as per the conversation with DK - I've kept the DTO for webhook simple by using string/List<string> instead of the enums. I've included some static classes with the constants (WebhookFormats.cs and EventTypes.cs), but this doesn't feel very useful.

![image](https://github.com/user-attachments/assets/29a3f42a-d64c-4bd1-bd40-52dbbfddb724)
![image](https://github.com/user-attachments/assets/90773ab4-f25f-4311-8ae6-fcd8b5d2dde7)
